### PR TITLE
fixed the repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ssh pi@ip_address
 Connect to your Pwnagotchi via SSH and clone this repository:
 
 ```bash
-git clone https://github.com/V0r-T3x/pwnagotchi-bootanimations.git
+git clone https://github.com/itsOwen/pwnagotchi-bootanimations.git
 cd pwnagotchi-bootanimations
 ```
 


### PR DESCRIPTION
I used my repo and did not change it before the merge. The link should lead to the main repo.